### PR TITLE
#150798551 Create dashboard for unresolved issues

### DIFF
--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -31,6 +31,7 @@ channel_urls = [
 urlpatterns = [
     url(r'^$', views.index, name="hc-index"),
     url(r'^checks/$', views.my_checks, name="hc-checks"),
+    url(r'^checks/unresolved/$', views.my_checks, name="hc-unresolved-checks"),
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -30,32 +30,47 @@ def pairwise(iterable):
 @login_required
 def my_checks(request):
     q = Check.objects.filter(user=request.team.user).order_by("created")
-    checks = list(q)
+    all_checks = list(q)
 
     counter = Counter()
-    down_tags, grace_tags = set(), set()
-    for check in checks:
-        status = check.get_status()
-        for tag in check.tags_list():
-            if tag == "":
-                continue
+    if not 'unresolved' in request.path:
+        down_tags, grace_tags = set(), set()
+        for check in all_checks:
+            status = check.get_status()
+            for tag in check.tags_list():
+                if tag == "":
+                    continue
 
-            counter[tag] += 1
+                counter[tag] += 1
 
-            if status == "down":
-                down_tags.add(tag)
-            elif check.in_grace_period():
-                grace_tags.add(tag)
+                if status == "down":
+                    down_tags.add(tag)
+                elif check.in_grace_period():
+                    grace_tags.add(tag)
 
-    ctx = {
-        "page": "checks",
-        "checks": checks,
-        "now": timezone.now(),
-        "tags": counter.most_common(),
-        "down_tags": down_tags,
-        "grace_tags": grace_tags,
-        "ping_endpoint": settings.PING_ENDPOINT
-    }
+        ctx = {
+            "page": "checks",
+            "checks": all_checks,
+            "now": timezone.now(),
+            "tags": counter.most_common(),
+            "down_tags": down_tags,
+            "grace_tags": grace_tags,
+            "ping_endpoint": settings.PING_ENDPOINT
+        }
+
+    else:
+        unresolved = []
+        for check in all_checks:
+            if check.get_status() == "down":
+                print (check)
+                unresolved.append(check)
+
+        ctx = {
+            "page": "unresolved",
+            "checks": unresolved,
+            "now": timezone.now(),
+            "ping_endpoint": settings.PING_ENDPOINT
+        }
 
     return render(request, "front/my_checks.html", ctx)
 

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -28,6 +28,18 @@
         {% endfor %}
     </div>
     {% endif %}
+    <ul class="nav nav-tabs">
+      <li {% if page == "checks" %}
+        class="active"
+        {% endif %}>
+          <a href="{% url 'hc-checks' %}">ALL</a>
+      </li>
+      <li {% if page == "unresolved" %}
+        class="active"
+        {% endif %}>
+        <a href="{% url 'hc-unresolved-checks' %}">UNRESOLVED</a>
+      </li>
+    </ul>
 
 </div>
 <div class="row">
@@ -38,16 +50,23 @@
         {% include "front/my_checks_mobile.html" %}
         {% include "front/my_checks_desktop.html" %}
     {% else %}
-    <div class="alert alert-info">You don't have any checks yet.</div>
+        {% if page == "checks" %}
+            <div class="alert alert-info">You don't have any checks yet.</div>
+        {% endif %}
+        {% if page == "unresolved" %}
+            <div class="alert alert-info">Woohoo!! You don't have any unresolved checks.</div>
+        {% endif %}
     {% endif %}
     </div>
 </div>
 <div class="row">
     <div class="col-sm-12">
-        <form method="post" action="{% url 'hc-add-check' %}" class="text-center">
-            {% csrf_token %}
-            <input type="submit" class="btn btn-primary btn-lg" value="Add Check">
-        </form>
+        {% if not page == "unresolved" %}
+            <form method="post" action="{% url 'hc-add-check' %}" class="text-center">
+                {% csrf_token %}
+                <input type="submit" class="btn btn-primary btn-lg" value="Add Check">
+            </form>
+        {% endif %}
     </div>
 </div>
 


### PR DESCRIPTION
#### What does this PR do?
In this PR, a tab for unresolved issues is created
#### Description of Task to be completed?
Creating of the new tab involved adding navbar tabs in the the `my_checks.html` page and rendering appropriate content for the appropriate tabs that is for the `ALL` tab, all the checks are rendered and on the `UNRESOLVED` tab, only "down" checks are rendered.
#### How should this be manually tested?
Clone the repository and set it up as specified in the `README.md`. Run `git checkout ft-dashboard-unresolved-issues-150798551` to use this branch and run the runserver with `./manage.py runserver`
#### Any background context you want to provide?
Previously, all the checks have been rendered in the same page with no special attention given to the unresolved issues
#### What are the relevant pivotal tracker stories?
#150798551
#### Screenshots 
ALL TAB
![image](https://user-images.githubusercontent.com/11851029/30354717-d38179ec-9836-11e7-8f9b-bfe16716af21.png)
UNRESOLVED TAB
![image](https://user-images.githubusercontent.com/11851029/30354724-db118418-9836-11e7-89c2-818b3d6838f9.png)
